### PR TITLE
Add `Sync` bound to `Send` impl of `LockWeak<T>`

### DIFF
--- a/parc/src/lib.rs
+++ b/parc/src/lib.rs
@@ -380,7 +380,7 @@ impl<T> LockWeak<T> {
     }
 }
 
-unsafe impl<T> Send for LockWeak<T> {}
+unsafe impl<T: Sync> Send for LockWeak<T> {}
 
 /// Unclonable owned reference to a [`ParentArc`](struct.ParentArc.html).
 ///


### PR DESCRIPTION
Hello! :crab:,
While scanning crates.io., we (Rust group @sslab-gatech) have noticed a soundness/memory safety issue in this crate which allows safe Rust code to trigger undefined behavior. This PR adds a small fix to resolve the issue.

## Issue
It is possible to create data races by enclosing a
non-Sync type data to `ParentArc` and by accessing the enclosed data
from multiple threads via `ChildArc`.

This is possible since there is no bound on `T` of impl `Send` for `LockWeak<T>`.
```rust
unsafe impl<T> Send for LockWeak<T> {}
```

## Proof of Concept
I prepared a minimal example that incurs undefined behavior while using the `parc` crate with safe Rust.
To observe undefined behavior, you need to run the below program in Debug mode.
Since Rc's internal `strong_count` is updated by multiple threads without synchronization,
the program will terminate in either one of the following states.
* `strong_count` > 1
  * program panics at the assertion check at the end (memory leak)
* `strong_count` == 0
  * Rc is dropped while references to it are still alive.
    When run on Ubuntu 18.04, program crashes with error: `Illegal Instruction (Core Dumped)`
* `strong_count` == 1
   * Not impossible, but highly unlikely

```rust
#![forbid(unsafe_code)]

use parc::ParentArc;
use std::rc::Rc;

fn main() {
    // `Rc` neither implements `Send` nor `Sync`.
    let parent = ParentArc::new(Rc::new(0));

    let mut children = vec![];
    for _ in 0..5 {
        let weak = ParentArc::downgrade(&parent);
        let child_thr = std::thread::spawn(move || {
            loop {
                // `weak` is moved into child thread.
                let child = weak.upgrade();
                match child {
		    Some(rc) => {
                        for _ in 0..2000 {
                            // `strong_count` of `rc`
                            // is updated by multiple threads without synchronization.
                            let _ = Rc::clone(rc.as_ref());
                        }
                        break;
                    }
		    None => continue,
                }
            }
        });
        children.push(child_thr);
    }
    for child_thr in children {
        child_thr.join().expect("Failed to join with child thread");
    }
 
    let rc = parent.block_into_inner();

    // if (`strong_count` > 1): indicates a memory leak
    assert_eq!(1, Rc::strong_count(&rc));
}
```

## Solution to the issue
The issue exists due to the fact that sending `LockWeak` to multiple threads can let multiple threads concurrently
access the underlying data. This PR addresses the issue by adding a `Sync` bound in the `Send` impl of `LockWeak`.

Please let me know if there are any concerns regarding this change, and
**thank you for reviewing this PR** :cat: 